### PR TITLE
fix clippy warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ratelimit"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Brian Martin <brayniac@gmail.com>"]
 
 license = "MIT OR Apache-2.0"
@@ -17,4 +17,4 @@ keywords = [ "ratelimit", "tokenbucket", "rate", "token", "bucket" ]
 
 [dependencies]
 time = "0.1.34"
-shuteye = "0.1.0"
+shuteye = "0.1.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,7 +92,6 @@ pub struct Ratelimit {
 }
 
 impl Ratelimit {
-
     /// create a new ratelimit instance
     ///
     /// # Example
@@ -171,11 +170,8 @@ impl Ratelimit {
         if self.interval == 0 {
             return;
         }
-        match self.take(time::precise_time_ns(), count) {
-            Some(ts) => {
-                let _ = shuteye::sleep(ts);
-            }
-            None => {}
+        if let Some(ts) = self.take(time::precise_time_ns(), count) {
+            let _ = shuteye::sleep(ts);
         }
     }
 
@@ -207,9 +203,7 @@ impl Ratelimit {
             Err(_) => {
                 panic!("error getting Timespec from wait_time");
             }
-            Ok(ts) => {
-                Some(ts)
-            }
+            Ok(ts) => Some(ts),
         }
     }
 


### PR DESCRIPTION
- fix clippy warnings
- update shuteye to 0.1.1
- bump version to 0.2.3