### PR TITLE
More user-friendly API.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
-target
-Cargo.lock
 *.bk
+*.swp
+*~
+Cargo.lock
+target

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,5 +18,8 @@ keywords = [ "ratelimit", "tokenbucket", "rate", "token", "bucket" ]
 [dependencies]
 shuteye = "0.3.2"
 
+[dev-dependencies]
+lazy_static = "0.2.8"
+
 [features]
 unstable = []


### PR DESCRIPTION
I was trying to use this crate and stumbled upon the API. I figure that it's easier to just offer a redesign and ask for critique.

Basically, the changes are:

* made `cycles` not public because I don't think it was supposed to be
* renamed `Config` to `Builder` so that it makes a bit more sense
* removed `Ratelimit::new` because it was confusing; it makes more sense to say `Ratelimit::default`
* removed `Ratelimit::configure` and replaced it with `Builder::new`
* renamed `block` to `wait_for` and added `wait` which is just `wait_for(1)`
* wrapped `clone_sender` into an opaque `Handle` type with methods `wait` and `try_go` instead of `send` and `try_send`
* renamed `Ratelimit` to `Limiter`
* made `run` private and encapsulated it in a `SyncLimiter`, which spawns a `run` thread and offers the creation of `Handle`

It may be easier to understand the changes by just running `cargo doc` and viewing the changes directly. Let me know what you think of the changes!

A few other potential things that could be done to the docs:

1. Clarify exactly what quantum/capacity/interval actually mean, explaining the algorithm more in detail. I understand this but can't really fully word it right now.
2. Specify a few use case examples for configurations that make use of the above.

PS: thanks for the great crate!