### PR TITLE
bugfix: use std::thread::sleep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ readme = "README.md"
 keywords = [ "ratelimit", "tokenbucket", "rate", "token", "bucket" ]
 
 [dependencies]
-shuteye = "0.3.2"
 
 [dev-dependencies]
 lazy_static = "0.2.8"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,12 +100,8 @@
 #[cfg(feature = "unstable")]
 extern crate test;
 
-extern crate shuteye;
-
-
-use shuteye::sleep;
 use std::sync::{Arc, atomic, mpsc};
-use std::thread::spawn;
+use std::thread::{sleep, spawn};
 use std::time::{Duration, Instant};
 
 /// A builder for a rate limiter.
@@ -522,8 +518,6 @@ mod tests {
 
     use super::*;
     use std::time::Duration;
-
-    extern crate shuteye;
 
     #[test]
     fn test_cycles() {


### PR DESCRIPTION
- use std::thread::sleep instead of shuteye. Improves compatibility with non linux/mac targets