### PR TITLE
bugfix: fix multi-threaded ratelimiting

### DIFF
--- a/examples/global_ratelimit.rs
+++ b/examples/global_ratelimit.rs
@@ -1,0 +1,31 @@
+extern crate ratelimit;
+
+use std::thread;
+use std::time::Instant;
+
+pub fn main() {
+    let mut limiter = ratelimit::Builder::new().build();
+    let handle = limiter.make_handle();
+
+    thread::spawn(move || limiter.run());
+
+    let mut threads = Vec::new();
+    for _ in 0..10 {
+        let handle = handle.clone();
+        threads.push(thread::spawn(move || worker(handle)));
+    }
+    for thread in threads {
+        thread.join().unwrap();
+    }
+}
+
+pub fn worker(mut handle: ratelimit::Handle) {
+    for _ in 0..6 {
+        loop {
+            if handle.try_wait().is_ok() {
+                println!("{:?}", Instant::now());
+                break;
+            }
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,6 @@
 //! ```
 //! extern crate ratelimit;
 //!
-//! use std::thread;
 //! use std::time::Duration;
 //!
 //! let mut ratelimit = ratelimit::Builder::new()
@@ -38,70 +37,47 @@
 //!     ratelimit.wait();
 //! }
 //! println!("Ignition!");
+//! ```
 //!
-//! // make a multithreaded version
-//! let multi = ratelimit.sync();
+//! Use the `Limiter` to ratelimit multi-threaded cases
 //!
-//! // count down in a more awkward way
+//! ```
+//! extern crate ratelimit;
+//!
+//! use std::thread;
+//! use std::time::{Duration, Instant};
+//!
+//! let mut ratelimit = ratelimit::Builder::new()
+//!     .capacity(1) //number of tokens the bucket will hold
+//!     .quantum(1) //add one token per interval
+//!     .interval(Duration::new(1, 0)) //add quantum tokens every 1 second
+//!     .build();
+//! let mut handle = ratelimit.make_handle();
+//! thread::spawn(move || { ratelimit.run() });
+//!
+//! // launch threads
 //! let mut threads = Vec::new();
-//! static NUMS: &[&str] = &["Three", "Two", "One"];
-//! for num in &NUMS[..] {
-//!     let handle = multi.make_handle();
+//! for _ in 0..10 {
+//!     let mut handle = handle.clone();
 //!     threads.push(thread::spawn(move || {
 //!         handle.wait();
-//!         println!("{}!", num);
+//!         println!("current time: {:?}", Instant::now());
 //!     }));
 //! }
 //! for thread in threads {
 //!     thread.join().unwrap();
 //! }
-//! println!("Ignition?");
-//! ```
-//!
-//! Construct a static `SyncLimiter` to rate-limit an entire library.
-//!
-//! ```
-//! #[macro_use]
-//! extern crate lazy_static;
-//! extern crate ratelimit;
-//!
-//! use std::thread;
-//! use std::time::Duration;
-//!
-//! // our rate limiter (kept private to the outside world)
-//! lazy_static! {
-//!     static ref RATE_LIMITER: ratelimit::SyncLimiter = ratelimit::Builder::new()
-//!         .capacity(1)
-//!         .quantum(1)
-//!         .interval(Duration::new(1, 0))
-//!         .build_sync();
-//! }
-//!
-//! fn do_some_work() {
-//!     let handle = RATE_LIMITER.make_handle();
-//!     thread::spawn(move || {
-//!         handle.wait();
-//!         // do our work
-//!     });
-//! }
-//!
-//! # fn main() {
-//! // do a bunch of work
-//! for i in -10..0 {
-//!     do_some_work();
-//! }
-//! # }
+//! println!("time's up!");
 //! ```
 
 #![cfg_attr(test, deny(warnings))]
-
 #![cfg_attr(feature = "unstable", feature(test))]
 
 #[cfg(feature = "unstable")]
 extern crate test;
 
-use std::sync::{Arc, atomic, mpsc};
-use std::thread::{sleep, spawn};
+use std::sync::mpsc;
+use std::thread::sleep;
 use std::time::{Duration, Instant};
 
 /// A builder for a rate limiter.
@@ -117,7 +93,7 @@ pub struct Limiter {
     config: Builder,
     t0: Instant,
     available: f64,
-    tx: mpsc::SyncSender<()>,
+    tx: Handle,
     rx: mpsc::Receiver<()>,
 }
 
@@ -125,89 +101,137 @@ pub struct Limiter {
 #[derive(Clone)]
 pub struct Handle {
     inner: mpsc::SyncSender<()>,
+    available: usize,
 }
 unsafe impl Sync for Handle {}
+
 impl Handle {
-    /// Waits for a single token.
+    /// Block for 1 token
     ///
     /// # Examples
     ///
     /// ```
-    /// # use ratelimit::SyncLimiter;
+    /// # use ratelimit::Builder;
     /// # use std::thread;
-    /// let multi = SyncLimiter::default();
+    /// let mut limiter = Builder::default().build();
+    /// let mut handle = limiter.make_handle();
+    ///
+    /// thread::spawn(move || { limiter.run() });
+    ///
+    /// let mut threads = Vec::new();
     ///
     /// for i in 0..2 {
-    ///     let s = multi.make_handle();
-    ///     thread::spawn(move || {
+    ///     let mut handle = handle.clone();
+    ///     threads.push(thread::spawn(move || {
     ///         for x in 0..5 {
-    ///             s.wait();
+    ///             handle.wait();
     ///             println!(".");
     ///         }
-    ///     });
+    ///     }));
     /// }
-    pub fn wait(&self) {
-        // NOTE: we *don't* unwrap the value here because the only case where this would
-        // actually happen is if the `SyncLimiter` was dropped, thus dropping the original
-        // `Limiter`. this behaviour is documented in the docs for `SyncLimiter`
-        let _ = self.inner.send(());
+    pub fn wait(&mut self) {
+        if self.available >= 1 {
+            self.available -= 1;
+        } else {
+            loop {
+                if self.inner.try_send(()).is_ok() {
+                    break;
+                }
+                sleep(Duration::new(0, 1_000));
+            }
+        }
     }
 
-    /// Waits for `count` tokens.
+    /// Block for `count` tokens
     ///
     /// # Examples
     ///
     /// ```
-    /// # use ratelimit::SyncLimiter;
+    /// # use ratelimit::Builder;
     /// # use std::thread;
-    /// let multi = SyncLimiter::default();
+    /// let mut limiter = Builder::default().build();
+    /// let mut handle = limiter.make_handle();
+    ///
+    /// thread::spawn(move || { limiter.run() });
+    ///
+    /// let mut threads = Vec::new();
     ///
     /// for i in 0..2 {
-    ///     let s = multi.make_handle();
-    ///     thread::spawn(move || {
+    ///     let mut handle = handle.clone();
+    ///     threads.push(thread::spawn(move || {
     ///         for x in 0..5 {
-    ///             s.wait_for(1);
+    ///             handle.wait_for(1);
     ///             println!(".");
     ///         }
-    ///     });
+    ///     }));
     /// }
-    pub fn wait_for(&self, count: u32) {
+    pub fn wait_for(&mut self, count: usize) {
         for _ in 0..count {
             self.wait();
         }
     }
 
-    /// Checks if we would be able to get a token, and returns whether we got it.
+    /// Non-blocking wait for one token.
+    /// Returns Ok(()) if no wait required.
+    /// Returns Err(()) if wait would block.
     ///
     /// # Examples
     ///
     /// ```
-    /// # use ratelimit::SyncLimiter;
-    /// let multi = SyncLimiter::default();
-    /// let handle = multi.make_handle();
+    /// # use ratelimit::Builder;
+    /// let mut limiter = Builder::new().build();
+    /// let mut handle = limiter.make_handle();
     ///
-    /// if handle.try_get() {
-    ///     println!("not limited");
+    /// if handle.try_wait().is_ok() {
+    ///     println!("token granted");
     /// } else {
-    ///     println!("was limited");
+    ///     println!("would block");
     /// }
-    #[cfg_attr(feature = "cargo-clippy", allow(match_same_arms))]
-    pub fn try_get(&self) -> bool {
-        match self.inner.try_send(()) {
-            // if it sent, yes, we sent
-            Ok(()) => true,
+    pub fn try_wait(&mut self) -> Result<(), ()> {
+        self.try_wait_for(1)
+    }
 
-            // this also counts as being sent, because `wait` will still continue on err
-            Err(mpsc::TrySendError::Disconnected(())) => true,
-
-            // this means that we would have to wait
-            Err(mpsc::TrySendError::Full(())) => false,
+    /// Non-blocking wait for `count` token.
+    /// Returns Ok(()) if no wait required.
+    /// Returns Err(()) if wait would block.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use ratelimit::Builder;
+    /// let mut limiter = Builder::new().build();
+    /// let mut handle = limiter.make_handle();
+    ///
+    /// if handle.try_wait_for(2).is_ok() {
+    ///     println!("tokens granted");
+    /// } else {
+    ///     println!("would block");
+    /// }
+    pub fn try_wait_for(&mut self, count: usize) -> Result<(), ()> {
+        if count <= self.available {
+            self.available -= count;
+            Ok(())
+        } else {
+            let needed = count - self.available;
+            for _ in 0..needed {
+                if self.inner.try_send(()).is_ok() {
+                    self.available += 1;
+                } else {
+                    break;
+                }
+            }
+            if self.available == count {
+                self.available = 0;
+                Ok(())
+            } else {
+                Err(())
+            }
         }
     }
 }
 
 impl Builder {
-    /// Creates a new builder.
+    /// Creates a new Builder with the default config
     ///
     /// # Examples
     ///
@@ -218,35 +242,26 @@ impl Builder {
         Builder::default()
     }
 
-    /// Builds a rate limiter from the given config.
+
+    /// Returns a Limiter from the Builder.
     ///
-    /// # Examples
-    ///
+    /// # Example
     /// ```
     /// # use ratelimit::Builder;
+    ///
     /// let mut r = Builder::new().build();
     pub fn build(self) -> Limiter {
-        Limiter::new(self)
+        Limiter::configured(self)
     }
 
-    /// Builds a multi-threaded rate limiter from the given config.
+    /// Sets the number of tokens to add per interval.
     ///
     /// # Examples
     ///
     /// ```
-    /// # use ratelimit::Builder;
-    /// let mut r = Builder::new().build_sync();
-    pub fn build_sync(self) -> SyncLimiter {
-        Limiter::new(self).sync()
-    }
-
-    /// Sets the number of tokens that are added at each interval.
+    /// # use ratelimit::Limiter;
     ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use ratelimit::Builder;
-    /// let mut r = Builder::new()
+    /// let mut r = Limiter::configure()
     ///     .quantum(100)
     ///     .build();
     pub fn quantum(mut self, quantum: u32) -> Self {
@@ -259,8 +274,9 @@ impl Builder {
     /// # Examples
     ///
     /// ```
-    /// # use ratelimit::Builder;
-    /// let mut r = Builder::new()
+    /// # use ratelimit::Limiter;
+    ///
+    /// let mut r = Limiter::configure()
     ///     .capacity(100)
     ///     .build();
     pub fn capacity(mut self, capacity: u32) -> Self {
@@ -273,9 +289,10 @@ impl Builder {
     /// # Examples
     ///
     /// ```
-    /// # use ratelimit::Builder;
+    /// # use ratelimit::Limiter;
     /// # use std::time::Duration;
-    /// let mut r = Builder::new()
+    ///
+    /// let mut r = Limiter::configure()
     ///     .interval(Duration::new(2, 0))
     ///     .build();
     pub fn interval(mut self, interval: Duration) -> Self {
@@ -283,27 +300,29 @@ impl Builder {
         self
     }
 
-    /// Alternative to `interval`; sets the number of tokens adds per second.
+    /// Alternative to `interval`; sets the number of times
+    /// that tokens will be added to the bucket each second.
     ///
     /// # Examples
     ///
     /// ```
-    /// # use ratelimit::Builder;
+    /// # use ratelimit::Limiter;
+    ///
     /// let mut rate = 100_000; // 100kHz
-    /// let mut r = Builder::new()
+    /// let mut r = Limiter::configure()
     ///     .frequency(rate)
     ///     .build();
-    pub fn frequency(mut self, per_sec: u32) -> Self {
+    pub fn frequency(mut self, cycles: u32) -> Self {
         let mut interval = Duration::new(1, 0);
-        interval /= per_sec;
+        interval /= cycles;
         self.interval = interval;
         self
     }
 }
 
 impl Default for Builder {
-    fn default() -> Builder {
-        Builder {
+    fn default() -> Self {
+        Self {
             start: Instant::now(),
             capacity: 1,
             quantum: 1,
@@ -318,88 +337,86 @@ impl Default for Limiter {
     }
 }
 
-/// Multi-threaded rate limiter.
-///
-/// If the rate limiter is dropped before any handles, then the handles will always succeed without
-/// any rate limiting. Similarly, if this limiter is leaked, all handles will continue to rate limit
-/// properly, although the thread handling the requests will continue to run until the program
-/// exits.
-pub struct SyncLimiter {
-    run_thread: Arc<atomic::AtomicBool>,
-    handle: Handle,
-}
-impl SyncLimiter {
-    /// Gets a handle to this rate limiter.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use ratelimit::SyncLimiter;
-    /// # use std::thread;
-    ///
-    /// let multi = SyncLimiter::default();
-    ///
-    /// for i in 0..2 {
-    ///     let s = multi.make_handle();
-    ///     thread::spawn(move || {
-    ///         for x in 0..5 {
-    ///             s.wait();
-    ///             println!(".");
-    ///         }
-    ///     });
-    /// }
-    pub fn make_handle(&self) -> Handle {
-        self.handle.clone()
-    }
-}
-impl From<Limiter> for SyncLimiter {
-    fn from(mut rl: Limiter) -> Self {
-        let atomic = Arc::new(atomic::AtomicBool::new(false));
-        let cond = atomic.clone();
-
-        let handle = Handle { inner: rl.tx.clone() };
-        spawn(move || while cond.load(atomic::Ordering::Relaxed) {
-            rl.run();
-        });
-
-        SyncLimiter {
-            run_thread: atomic,
-            handle: handle,
-        }
-    }
-}
-impl Default for SyncLimiter {
-    fn default() -> Self {
-        Limiter::default().into()
-    }
-}
-impl Drop for SyncLimiter {
-    fn drop(&mut self) {
-        self.run_thread.store(false, atomic::Ordering::Relaxed)
-    }
-}
-
 impl Limiter {
-    fn new(config: Builder) -> Limiter {
+    /// create a new default ratelimit instance
+    ///
+    /// # Example
+    /// ```
+    /// # use ratelimit::Limiter;
+    ///
+    /// let mut r = Limiter::new();
+    pub fn new() -> Limiter {
+        Default::default()
+    }
+
+    /// create a new `Config` for building a custom `Limiter`
+    ///
+    /// # Example
+    /// ```
+    /// # use ratelimit::Limiter;
+    ///
+    /// let mut r = Limiter::configure().build();
+    pub fn configure() -> Builder {
+        Builder::default()
+    }
+
+    // internal function for building a Limiter from its Config
+    fn configured(config: Builder) -> Limiter {
         let (tx, rx) = mpsc::sync_channel(config.capacity as usize);
+        for _ in 0..config.capacity {
+            let _ = tx.send(());
+        }
         let t0 = config.start;
         Limiter {
             config: config,
             t0: t0,
             available: 0.0,
-            tx: tx,
+            tx: Handle {
+                inner: tx,
+                available: 0,
+            },
             rx: rx,
         }
     }
 
-    // runs the rate limiter; for multithreaded version only
-    fn run(&mut self) {
-        let quantum = self.config.quantum;
+    /// Run the limiter, intended for multi-threaded use
+    ///
+    /// # Example
+    /// ```
+    /// # use ratelimit::Limiter;
+    /// # use std::thread;
+    ///
+    /// let mut limiter = Limiter::new();
+    ///
+    /// let mut handle = limiter.make_handle();
+    ///
+    /// thread::spawn(move || { limiter.run(); });
+    ///
+    /// handle.wait();
+    pub fn run(&mut self) {
+        // pre-fill the queue
+        loop {
+            if self.tx.inner.try_send(()).is_err() {
+                break;
+            }
+        }
+        // set available to 0
+        self.available = 0.0;
+        // reset t0
+        self.t0 = Instant::now();
+        loop {
+            self.run_once();
+        }
+    }
+
+    /// Run the limiter for a single tick
+    fn run_once(&mut self) {
+        let quantum = self.config.quantum as usize;
         self.wait_for(quantum);
         let mut unused = 0;
         for _ in 0..self.config.quantum {
             match self.rx.try_recv() {
-                Ok(()) => {}
+                Ok(..) => {}
                 Err(_) => {
                     unused += 1;
                 }
@@ -408,52 +425,62 @@ impl Limiter {
         self.give(unused as f64);
     }
 
-    /// Promotes this rate-limiter to a multithreaded version.
+    /// Create a Handle for multi-thread use
     ///
-    /// # Examples
-    ///
+    /// # Example
     /// ```
     /// # use ratelimit::Limiter;
-    /// let mut s = Limiter::default().sync();
-    pub fn sync(self) -> SyncLimiter {
-        SyncLimiter::from(self)
+    ///
+    /// let mut limiter = Limiter::new();
+    ///
+    /// let mut handle = limiter.make_handle();
+    ///
+    /// match handle.try_wait() {
+    ///     Ok(_) => {
+    ///         println!("not limited");
+    ///     },
+    ///     Err(_) => {
+    ///         println!("was limited");
+    ///     },
+    /// }
+    pub fn make_handle(&mut self) -> Handle {
+        self.tx.clone()
     }
 
-    /// Waits for a single token.
+    /// Blocking wait for 1 token.
     ///
-    /// # Examples
-    ///
+    /// # Example
     /// ```
     /// # use ratelimit::Limiter;
-    /// let mut r = Limiter::default();
+    ///
+    /// let mut limiter = Limiter::new();
     /// for i in -10..0 {
     ///     println!("T {}...", i);
-    ///     r.wait();
+    ///     limiter.wait();
     /// }
     /// println!("Ignition!");
     pub fn wait(&mut self) {
         self.wait_for(1)
     }
 
-    /// Waits for `count` tokens.
+    /// Blocking wait for `count` tokens.
     ///
-    /// # Examples
-    ///
+    /// # Example
     /// ```
     /// # use ratelimit::Limiter;
-    /// let mut r = Limiter::default();
-    /// for i in -10..0 {
-    ///     println!("T {}...", i);
-    ///     r.wait_for(1);
+    ///
+    /// let mut limiter = Limiter::new();
+    /// for i in 1..3 {
+    ///     println!("{}...", i);
+    ///     limiter.wait_for(i);
     /// }
-    /// println!("Ignition!");
-    pub fn wait_for(&mut self, count: u32) {
+    pub fn wait_for(&mut self, count: usize) {
         if let Some(wait) = self.take(Instant::now(), count) {
             sleep(wait);
         }
     }
 
-    // internal function to add tokens
+    // Internal function to add tokens to the bucket
     fn give(&mut self, count: f64) {
         self.available += count;
 
@@ -462,17 +489,17 @@ impl Limiter {
         }
     }
 
-    // return time to sleep until tokens are available
-    fn take(&mut self, t1: Instant, tokens: u32) -> Option<Duration> {
+    // Return time to sleep until `count` tokens are available
+    fn take(&mut self, t1: Instant, count: usize) -> Option<Duration> {
 
         // we don't need any tokens, just return
-        if tokens == 0 {
+        if count == 0 {
             return None;
         }
 
         // we have all tokens we need, fast path
-        if self.available >= tokens as f64 {
-            self.available -= tokens as f64;
+        if self.available >= count as f64 {
+            self.available -= count as f64;
             return None;
         }
 
@@ -480,15 +507,15 @@ impl Limiter {
         self.tick(t1);
 
         // do we have the tokens now?
-        if self.available >= tokens as f64 {
-            self.available -= tokens as f64;
+        if self.available >= count as f64 {
+            self.available -= count as f64;
             return None;
         }
 
         // we must wait
-        let need = tokens as f64 - self.available;
+        let need = count as f64 - self.available;
         let wait = self.config.interval * need.ceil() as u32;
-        self.available -= tokens as f64;
+        self.available -= count as f64;
 
         Some(wait)
     }
@@ -515,6 +542,9 @@ fn cycles(duration: Duration, period: Duration) -> f64 {
 mod tests {
     #[cfg(feature = "unstable")]
     extern crate test;
+
+    #[cfg(feature = "unstable")]
+    use std::thread;
 
     use super::*;
     use std::time::Duration;
@@ -545,7 +575,7 @@ mod tests {
 
     #[test]
     fn test_give() {
-        let mut r = Builder::new().capacity(1000).build();
+        let mut r = Builder::default().capacity(1000).build();
 
         assert_eq!(r.available, 0.0);
 
@@ -558,7 +588,7 @@ mod tests {
 
     #[test]
     fn test_tick() {
-        let mut r = Builder::new().capacity(1000).build();
+        let mut r = Builder::default().capacity(1000).build();
         let t = r.t0;
         r.tick(t + Duration::new(1, 0));
         assert_eq!(r.available, 1.0);
@@ -569,7 +599,7 @@ mod tests {
 
     #[test]
     fn test_take() {
-        let mut r = Builder::new().frequency(1000).capacity(1000).build();
+        let mut r = Builder::default().frequency(1000).capacity(1000).build();
         let t = r.t0;
         assert_eq!(r.take(t + Duration::new(1, 0), 1000), None);
         assert_eq!(
@@ -585,85 +615,89 @@ mod tests {
 
     #[cfg(feature = "unstable")]
     #[bench]
-    fn block_1_million_per_second_1000ns(b: &mut test::Bencher) {
-        let mut r = Builder::new()
+    fn interval_1000ns(b: &mut test::Bencher) {
+        let mut r = Builder::default()
             .capacity(10000)
-            .frequency(1_000_000)
+            .interval(Duration::new(0, 1_000))
             .build();
         b.iter(|| r.wait());
     }
 
     #[cfg(feature = "unstable")]
     #[bench]
-    fn block_2_million_per_second_500ns(b: &mut test::Bencher) {
-        let mut r = Builder::new()
+    fn interval_500ns(b: &mut test::Bencher) {
+        let mut r = Builder::default()
             .capacity(10000)
-            .frequency(2_000_000)
+            .interval(Duration::new(0, 500))
             .build();
         b.iter(|| r.wait());
     }
 
     #[cfg(feature = "unstable")]
     #[bench]
-    fn block_10_million_per_second_100ns(b: &mut test::Bencher) {
-        let mut r = Builder::new()
+    fn interval_100ns(b: &mut test::Bencher) {
+        let mut r = Builder::default()
             .capacity(10000)
-            .frequency(10_000_000)
+            .interval(Duration::new(0, 100))
             .build();
         b.iter(|| r.wait());
     }
 
     #[cfg(feature = "unstable")]
     #[bench]
-    fn block_20_million_per_second_50ns(b: &mut test::Bencher) {
-        let mut r = Builder::new()
+    fn interval_50ns(b: &mut test::Bencher) {
+        let mut r = Builder::default()
             .capacity(10000)
-            .frequency(20_000_000)
+            .interval(Duration::new(0, 50))
             .build();
         b.iter(|| r.wait());
     }
 
     #[cfg(feature = "unstable")]
     #[bench]
-    fn block_1_million_per_second_1000ns_sync(b: &mut test::Bencher) {
-        let r = Builder::new()
+    fn multi_interval_1000ns(b: &mut test::Bencher) {
+        let mut r = Builder::default()
             .capacity(10000)
-            .frequency(1_000_000)
-            .build_sync();
-        let h = r.make_handle();
+            .interval(Duration::new(0, 1_000))
+            .build();
+        let mut h = r.make_handle();
+        thread::spawn(move || { r.run(); });
         b.iter(|| h.wait());
     }
 
     #[cfg(feature = "unstable")]
     #[bench]
-    fn block_2_million_per_second_500ns_sync(b: &mut test::Bencher) {
-        let r = Builder::new()
+    fn multi_interval_500ns(b: &mut test::Bencher) {
+        let mut r = Builder::default()
             .capacity(10000)
-            .frequency(2_000_000)
-            .build_sync();
-        let h = r.make_handle();
+            .interval(Duration::new(0, 500))
+            .build();
+        let mut h = r.make_handle();
+        thread::spawn(move || { r.run(); });
         b.iter(|| h.wait());
     }
 
     #[cfg(feature = "unstable")]
     #[bench]
-    fn block_10_million_per_second_100ns_sync(b: &mut test::Bencher) {
-        let r = Builder::new()
+    fn multi_interval_100ns(b: &mut test::Bencher) {
+        let mut r = Builder::default()
             .capacity(10000)
-            .frequency(10_000_000)
-            .build_sync();
-        let h = r.make_handle();
+            .interval(Duration::new(0, 100))
+            .build();
+        let mut h = r.make_handle();
+        thread::spawn(move || { r.run(); });
         b.iter(|| h.wait());
     }
 
     #[cfg(feature = "unstable")]
     #[bench]
-    fn block_20_million_per_second_50ns_sync(b: &mut test::Bencher) {
-        let r = Builder::new()
+    fn multi_interval_50ns(b: &mut test::Bencher) {
+        let mut r = Builder::default()
             .capacity(10000)
-            .frequency(20_000_000)
-            .build_sync();
-        let h = r.make_handle();
+            .interval(Duration::new(0, 50))
+            .build();
+        let mut h = r.make_handle();
+        thread::spawn(move || { r.run(); });
         b.iter(|| h.wait());
     }
 }


### PR DESCRIPTION
- bugfix: SyncLimiter appears to not function properly, revert while retaining most of the new API. fixes #25 
- bugfix: reset Limiter state on call to run() to ensure rate starts at expected values. fixes #24 
- example: add a global ratelimit example